### PR TITLE
Add email to authentication response object

### DIFF
--- a/plugins/system/sociallogin/src/Library/Plugin/LoginTrait.php
+++ b/plugins/system/sociallogin/src/Library/Plugin/LoginTrait.php
@@ -738,6 +738,7 @@ trait LoginTrait
 		$response->status        = $statusSuccess;
 		$response->username      = $user->username;
 		$response->fullname      = $user->name;
+		$response->email         = $user->email;
 		$response->error_message = '';
 		$response->language      = $user->getParam('language');
 		$response->type          = 'SocialLogin';


### PR DESCRIPTION
Some third-party user group plugins rely on the email field to resolve users by email during onUserLogin. Tested successfully.

Pull Request for Issue # .

### Summary of Changes
Transmitted email value from user object to response object

### Testing Instructions
Login still work as before but retreive user email and make it available for other user plugin getting it from $user['email'] in onUserLogin

### Result before applying PR
3rd party other plugins were exiting as not able to retrive user from email as $user['email'] was not avaialble

### Result after applying PR
3rd party other plugins are now able to retrive user from email as $user['email'] has the user email.
Tested successfully on Joomla 6.0.2

### Backwards compatibility
Yes