### PR TITLE
Joomla 7.0 compatibility: forward-compatible event result handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 <?php die(); ?>
+Akeeba SocialLogin 4.11.0
+================================================================================
+~ Joomla 7.0 compatibility: forward-compatible event result handling for immutable events
+
 Akeeba SocialLogin 4.10.3
 ================================================================================
 # [HIGH] After social login, users were not redirected back to the protected page that triggered the login [gh-142]

--- a/plugins/system/sociallogin/src/Extension/SocialLogin.php
+++ b/plugins/system/sociallogin/src/Extension/SocialLogin.php
@@ -15,6 +15,7 @@ use Akeeba\Plugin\System\SocialLogin\Features\ButtonInjection;
 use Akeeba\Plugin\System\SocialLogin\Features\DynamicUsergroups;
 use Akeeba\Plugin\System\SocialLogin\Features\UserFields;
 use Akeeba\Plugin\System\SocialLogin\Library\Plugin\AddLoggerTrait;
+use Akeeba\Plugin\System\SocialLogin\Library\Plugin\EventResultTrait;
 use Akeeba\Plugin\System\SocialLogin\Library\Plugin\RunPluginsTrait;
 use Akeeba\Plugin\System\SocialLogin\Library\Plugin\SocialLoginButtonsTrait;
 use Exception;
@@ -41,6 +42,7 @@ class SocialLogin extends CMSPlugin implements SubscriberInterface, DatabaseAwar
 	use AddLoggerTrait;
 	use SocialLoginButtonsTrait;
 	use RunPluginsTrait;
+	use EventResultTrait;
 	use DatabaseAwareTrait;
 
 	/**

--- a/plugins/system/sociallogin/src/Features/ButtonInjection.php
+++ b/plugins/system/sociallogin/src/Features/ButtonInjection.php
@@ -110,16 +110,7 @@ trait ButtonInjection
 			];
 		}, $buttonDefinitions);
 
-		$result = $event->getArgument('result') ?: [];
-
-		if (!is_array($result))
-		{
-			$result = [$result];
-		}
-
-		$result[] = $ret;
-
-		$event->setArgument('result', $result);
+		$this->addEventResult($event, $ret);
 	}
 
 	/**

--- a/plugins/system/sociallogin/src/Features/UserFields.php
+++ b/plugins/system/sociallogin/src/Features/UserFields.php
@@ -82,11 +82,8 @@ trait UserFields
 		 * @param   object  $data     The user profile data
 		 */
 		[$context, $data] = array_values($event->getArguments());
-		$result   = $event->getArgument('result') ?: [];
-		$result   = is_array($result) ? $result : [$result];
-		$result[] = true;
 
-		$event->setArgument('result', $result);
+		$this->addEventResult($event, true);
 
 		// Check we are manipulating a valid form.
 		if (!in_array($context, ['com_admin.profile', 'com_users.user', 'com_users.profile', 'com_users.registration']))
@@ -135,8 +132,7 @@ trait UserFields
 			$data->sociallogin[$k] = $v[1];
 		}
 
-		$result[] = true;
-		$event->setArgument('result', $result);
+		$this->addEventResult($event, true);
 	}
 
 	/**
@@ -154,11 +150,8 @@ trait UserFields
 		 * @param   mixed  $data  The associated data for the form.
 		 */
 		[$form, $data] = array_values($event->getArguments());
-		$result   = $event->getArgument('result') ?: [];
-		$result   = is_array($result) ? $result : [$result];
-		$result[] = true;
 
-		$event->setArgument('result', $result);
+		$this->addEventResult($event, true);
 
 		if (!$this->addLinkUnlinkButtons)
 		{
@@ -275,14 +268,10 @@ trait UserFields
 		 * @var   string $msg     Message
 		 */
 		[$user, $success, $msg] = array_values($event->getArguments());
-		$result = $event->getArgument('result') ?: [];
-		$result = is_array($result) ? $result : [$result];
 
 		if (!$success)
 		{
-			$result[] = false;
-
-			$event->setArgument('result', $result);
+			$this->addEventResult($event, false);
 
 			return;
 		}
@@ -310,9 +299,7 @@ trait UserFields
 			$db->setQuery($query)->execute();
 		}
 
-		$result[] = true;
-
-		$event->setArgument('result', $result);
+		$this->addEventResult($event, true);
 	}
 
 	/**
@@ -326,20 +313,17 @@ trait UserFields
 	{
 		/**
 		 * @var   array $data   The user profile data which was saved.
-		 * @var   bool  $isNew  Is this a new user? (ignored)
-		 * @var   bool  $result Was the user saved successfully?
-		 * @var   mixed $error  (ignored)
+		 * @var   bool  $isNew   Is this a new user? (ignored)
+		 * @var   bool  $success Was the user saved successfully? (ignored)
+		 * @var   mixed $error   (ignored)
 		 */
-		[$data, $isNew, $result, $error] = array_values($event->getArguments());
-		$result   = $event->getArgument('result') ?: [];
-		$result   = is_array($result) ? $result : [$result];
-		$result[] = true;
+		[$data, $isNew, $success, $error] = array_values($event->getArguments());
 
-		$event->setArgument('result', $result);
+		$this->addEventResult($event, true);
 
 		$userId = ArrayHelper::getValue($data, 'id', 0, 'int');
 
-		if (!$userId || !$result || !isset($data['sociallogin']) || !is_array($data['sociallogin']) || !count($data['sociallogin']))
+		if (!$userId || !isset($data['sociallogin']) || !is_array($data['sociallogin']) || !count($data['sociallogin']))
 		{
 			return;
 		}

--- a/plugins/system/sociallogin/src/Library/Plugin/AbstractPlugin.php
+++ b/plugins/system/sociallogin/src/Library/Plugin/AbstractPlugin.php
@@ -169,6 +169,15 @@ abstract class AbstractPlugin extends CMSPlugin implements SubscriberInterface, 
 	/**
 	 * Return the event handles registered with this plugin
 	 *
+	 * NOTE ON RESULT HANDLING: The handlers below answer SocialLogin's *own* custom events
+	 * (onSocialLoginGetLoginButton, onSocialLoginGetLinkButton). These are dispatched by
+	 * RunPluginsTrait::runPlugins() as a mutable Joomla\CMS\Event\GenericEvent and the aggregated
+	 * button definitions are read back via the `result` argument (`$event['result']`). They must
+	 * therefore keep using `$event->setArgument('result', …)` and must NOT be switched to the
+	 * ResultAwareInterface::addResult() pattern (see EventResultTrait), which would write to a
+	 * different result store and silently break the button aggregation. The immutable-event concern
+	 * (Joomla 6.0+) only applies to the *core* Joomla events handled in the system plugin.
+	 *
 	 * @return string[]
 	 * @since  4.1.0
 	 */

--- a/plugins/system/sociallogin/src/Library/Plugin/EventResultTrait.php
+++ b/plugins/system/sociallogin/src/Library/Plugin/EventResultTrait.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ *  @package   AkeebaSocialLogin
+ *  @copyright Copyright (c)2016-2026 Nicholas K. Dionysopoulos / Akeeba Ltd
+ *  @license   GNU General Public License version 3, or later
+ */
+
+namespace Akeeba\Plugin\System\SocialLogin\Library\Plugin;
+
+// Protect from unauthorized access
+defined('_JEXEC') || die();
+
+use Joomla\Event\Event;
+use Joomla\Event\ResultAwareInterface;
+
+/**
+ * Helper trait for returning results from plugin event handlers in a forward-compatible way.
+ *
+ * Joomla 6.0 made many core events immutable. Writing a plugin result with
+ * `$event->setArgument('result', …)` (equivalent to the legacy `$event['result'][] = …`) is
+ * deprecated and throws on immutable events; the support for the old style has only been extended
+ * up to Joomla 7.0. Events implementing `ResultAwareInterface` must instead receive their results
+ * through `$event->addResult()`.
+ *
+ * This trait implements Joomla's officially recommended migration pattern: use `addResult()` when
+ * the event supports it and only fall back to the legacy `setArgument()` approach for older event
+ * objects. As a result the same code keeps working from Joomla 4.4 all the way to Joomla 7.0.
+ *
+ * @since 4.11.0
+ */
+trait EventResultTrait
+{
+	/**
+	 * Add a result to a plugin event in a forward-compatible manner.
+	 *
+	 * @param   Event  $event  The event to add the result to.
+	 * @param   mixed  $value  The result value to add.
+	 *
+	 * @return  void
+	 * @since   4.11.0
+	 */
+	protected function addEventResult(Event $event, $value): void
+	{
+		// Joomla 5.0+ result-aware (and immutable) events: append through the supported API.
+		if ($event instanceof ResultAwareInterface)
+		{
+			$event->addResult($value);
+
+			return;
+		}
+
+		// Legacy fallback for Joomla 4.x generic events which are not result-aware.
+		$result   = $event->getArgument('result') ?: [];
+		$result   = is_array($result) ? $result : [$result];
+		$result[] = $value;
+
+		$event->setArgument('result', $result);
+	}
+}


### PR DESCRIPTION
Pull Request for Issue #.

### Summary of Changes

Adds forward-compatible event result handling for Joomla 7.0's immutable events. Joomla 6.0+ introduced `ResultAwareInterface` for events that must use `addResult()` instead of the legacy `setArgument('result', …)` pattern. This PR introduces `EventResultTrait` that automatically detects event type and uses the appropriate API, ensuring compatibility from Joomla 4.4 through 7.0.

### Testing Instructions

* Verify plugin functionality on Joomla 4.4/5.x (legacy event handling via `setArgument()`)
* Verify plugin functionality on Joomla 6.0+ (result-aware event handling via `addResult()`)
* Test user profile form preparation and data handling
* Test social login button injection into login forms
* Test user deletion and post-save hooks

### Result before applying PR

On Joomla 6.0+, immutable events would throw exceptions or silently fail when plugins attempted to write results via the legacy `setArgument('result', …)` pattern. The plugin would not properly communicate results back to the event dispatcher.

### Result after applying PR

The plugin now detects whether an event implements `ResultAwareInterface` and uses the appropriate result-handling API:
- For Joomla 5.x and earlier: Uses legacy `setArgument('result', …)` 
- For Joomla 6.0+: Uses `addResult()` on result-aware events
- Same code works across all supported Joomla versions without modification

### Backwards compatibility

No breaking changes. This is purely additive—the new trait provides a compatibility layer that maintains support for older Joomla versions while enabling forward compatibility with Joomla 6.0+.

### Documentation Changes Required

None required. This is an internal implementation detail.

### Translation impact

None. No language strings added or removed.

### Technical information

The `EventResultTrait` implements Joomla's officially recommended migration pattern for handling immutable events. The trait is used by the system plugin's feature classes (`UserFields`, `ButtonInjection`) which handle core Joomla events that became immutable in Joomla 6.0.

**Important note:** Provider plugins (`AbstractPlugin` subclasses) dispatch their own custom events (`onSocialLoginGetLoginButton`, `onSocialLoginGetLinkButton`) as mutable `GenericEvent` objects. These must continue using the legacy `setArgument('result', …)` pattern and should NOT use `EventResultTrait`, as documented in the updated `AbstractPlugin` class comment. The trait is only for system plugin handlers of core Joomla events.

https://claude.ai/code/session_013v92tsJsffCvyhScyNhP57